### PR TITLE
fix subtitle in hgroup

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -343,7 +343,7 @@
         <p>見出しを説明を補強するような、副見出し、キャッチコピー、スローガンなどをマークアップできる</p>
         <pre><code class="html">&lt;hgroup&gt;
   &lt;h1&gt;deisui_html_radio #18&lt;/h1&gt;
-  &lt;h1&gt;〜マークアップは裏切らない〜&lt;/h1&gt;
+  &lt;h2&gt;〜マークアップは裏切らない〜&lt;/h2&gt;
 &lt;/hgroup&gt;</code></pre>
         <p>W3Cからは削除されたが、WHATWGでは仕様は残りつづけている。</p>
         <p>IE11、Edge含む全てのブラウザで対応済み</p>


### PR DESCRIPTION
`hgroup` 内で同レベルの見出しが並ぶ場合は、代替見出し（同内容だが併記したい）場合ぽい。サブタイトルの場合は、レベルを一つ落とす感じ。

See also https://html.spec.whatwg.org/multipage/sections.html#the-hgroup-element